### PR TITLE
Slightly changed the API and removed "href='#'" from the "view more" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cutter.js
-Cutter.js is a class to truncate HTML code to limit its length, by words number, without losing the markup.
+Cutter.js is a library used for truncating HTML code to limit its length, by word number, without losing the markup.
 
 ## Description
 
@@ -36,37 +36,32 @@ Insert in your code:
 
 ### Simple execution:
 
-	Cutter.run(oApplyTo, oTarget, nWords, [oTexts, oClasses]);
+	Cutter.run(oApplyTo, oTarget, nWords, [configuration]);
 
 ####Mandatory
 
-  >  **oAplyTo**: The element where the cutter will cut the content
+  >  **oAplyTo**: The element that will have its text truncated
 
-  >  **oTarget**: The element where the content will be attached after cut it.
+  >  **oTarget**: The element where the truncated content will be placed.
 
-  >  **nWords**: Number of words to cut the content.
+  >  **nWords**: Maximum word count. Any additional word will be truncated.
 
 ####Optional
 
-  >  **oTexts**: The texts config object with the text that will be showed if the link, to open the full content,is needed
+  >  **configuration**: This object contains both the text that will be displayed in the "view more" link and its style.
 
-  >>    oTexts by default: { more: "View more"}.
+  >>    configuration.viewMoreText: The text that will be displayed in the "view more" link. The default is "View more"
 
-  >  **oClasses**: The style config object with the class to style the link if needed.
-
-  >>    oClasses by default: { more: "more"}.
+  >>    configuration.class: The class that will be applied to the "View more" link. The default is "more"
 
 *Tip: oTarget Could be the same oApplyTo element if we want to replace the full content with the cut content*
 
-*Tip: If you only need to change the style you must put "undefined" where oTexts must be placed.*
+## Example
 
-## Documentation
+cutElement = document.getElementById("test");
+Cutter.run(cutElement, cutElement, 30, {viewMoreText:"Expand", class:"expandLink"});
 
-(Links will only work if you clone the repo.)
-
-[API documentation](https://github.com/tcorral/Cutter.js/examples_and_documents/jsdoc/index.html)
-
-[Examples](https://github.com/tcorral/Cutter.js/examples_and_documents/index.html) to see for yourself!
+*On the example above, the element with id "test" will display a maximum of 30 words and a link entitled "Expand". The "expandLink" class will be applied to this link. The remaining words that were previously truncated will show up in the element when the link is clicked.
 
 ## License
 

--- a/src/Cutter.js
+++ b/src/Cutter.js
@@ -5,28 +5,6 @@
 		Cutter = null;
 
 	/**
-	 * CutterClasses is the config singleton for classes used in Cutter
-	 * @class CutterClasses
-	 * @constructor
-	 * @author Tomas Corral Casas
-	 * @version 1.0
-	 * @type Object
-	 */
-	CutterClasses = function () {
-		this.more = "more";
-	};
-	/**
-	 * CutterTexts is the config singleton for texts used in Cutter
-	 * @class CutterTexts
-	 * @constructor
-	 * @author Tomas Corral Casas
-	 * @version 1.0
-	 * @type Object
-	 */
-	CutterTexts = function () {
-	    this.more =  "View more";
-	};
-	/**
 	 * Cutter is a class that allows HTML code to cut a number of words contained in the nodes, keeping intact the HTML markup.
 	 * @author Tomas Corral Casas
 	 * @version 1.0
@@ -62,14 +40,14 @@
 	     * @author Tomas Corral Casas
 	     * @type Object
 	     */
-	    this.oClasses = new CutterClasses();
+	    this.oClasses = "more";
 	    /**
 	     * oTexts is the config singleton for texts used in Cutter
 	     * @member Cutter.prototype
 	     * @author Tomas Corral Casas
 	     * @type Object
 	     */
-	    this.oTexts = new CutterTexts();
+	    this.oTexts = "View more";
 	    /**
 	     * nWords is the number of words to Cut
 	     * @member Cutter.prototype
@@ -187,14 +165,14 @@
 	    return this;
 	};
 	/**
-	 * setTexts is the method that sets the config singleton of Texts used in Cutter
+	 * setText is the method that sets the text displayed in the "view more" link.
 	 * @member Cutter.prototype
 	 * @author Tomas Corral Casas
 	 * @param  {object} oTexts This is the singleton config
 	 * @return the instance of the Cutter
 	 * @type Object
 	 */
-	Cutter.prototype.setTexts = function (oTexts) {
+	Cutter.prototype.setText = function (oTexts) {
 	    if (!oTexts) {
 			return this;
 	    }
@@ -261,10 +239,9 @@
 	 */
 	Cutter.prototype.createViewMore = function () {
 		var oLink = doc.createElement("a");
-		oLink.className = this.oClasses.more;
-		oLink.title = this.oTexts.more;
-		oLink.href = "#";
-		oLink.innerHTML = this.oTexts.more;
+		oLink.className = this.oClasses;
+		oLink.title = this.oTexts;
+		oLink.innerHTML = this.oTexts;
 		this.oViewMore = oLink;
 	};
 	/**
@@ -531,15 +508,19 @@
 		}
 		this.oTarget.appendChild(this.oDocumentFragment);
 	};
-	Cutter.run = function (oApplyTo, oTarget, nWords, oTexts, oClasses) {
+	Cutter.run = function (oApplyTo, oTarget, nWords, configuration) {
 		var oCutter = new Cutter();
 		oCutter.applyTo(oApplyTo).setTarget(oTarget).setWords(nWords);
-		if (typeof oTexts !== "undefined") {
-			oCutter.setTexts(oTexts);
+
+		if (typeof configuration !== "undefined") {
+			if (typeof configuration.viewMoreText !== "undefined") {
+				oCutter.setText(configuration.viewMoreText);
+			}
+			if (typeof configuration.class !== "undefined") {
+				oCutter.setClasses(configuration.class);
+			}
 		}
-		if (typeof oClasses !== "undefined") {
-			oCutter.setClasses(oClasses);
-		}
+
 		oCutter.init();
 	};
 	win.Cutter = Cutter;

--- a/test/CutterTest.js
+++ b/test/CutterTest.js
@@ -6,7 +6,7 @@ function cutterTearDown()
 {
 	this.oCutter = null;
 }
-TestCase("CutterConstuctorTest", sinon.testCase({
+TestCase("CutterConstructorTest", sinon.testCase({
 	setUp: cutterSetUp,
 	"test should return null for the oApply property by default": function()
 	{
@@ -22,11 +22,11 @@ TestCase("CutterConstuctorTest", sinon.testCase({
 	},
 	"test should return CutterClasses instance for oClasses by default": function()
 	{
-		assertObject(this.oCutter.oClasses);
+		assertEquals("more", this.oCutter.oClasses);
 	},
 	"test should return CutterTexts instance for oTexts by default": function()
 	{
-		assertObject(this.oCutter.oTexts);
+		assertEquals("View more", this.oCutter.oTexts);
 	},
 	"test should return 0 for nWords by default": function()
 	{
@@ -95,7 +95,7 @@ TestCase("CutterApplyToTest", sinon.testCase({
 
 		assertSame(oObject, this.oCutter.oBackupApplyTo);
 	},
-	"test should return the Cutter instance if we don't provide nothing": function()
+	"test should return the Cutter instance if we don't provide anything": function()
 	{
 		var oResult = null;
 
@@ -284,7 +284,7 @@ TestCase("CutterSetTextsTest", sinon.testCase({
 		var oObject = {};
 		this.oCutter.oTexts = oObject;
 
-		this.oCutter.setTexts();
+		this.oCutter.setText();
 
 		assertSame(oObject, this.oCutter.oTexts);
 	},
@@ -293,7 +293,7 @@ TestCase("CutterSetTextsTest", sinon.testCase({
 		var oObject = {};
 		this.oCutter.oTexts = oObject;
 
-		this.oCutter.setTexts(null);
+		this.oCutter.setText(null);
 
 		assertSame(oObject, this.oCutter.oTexts);
 	},
@@ -301,7 +301,7 @@ TestCase("CutterSetTextsTest", sinon.testCase({
 	{
 		var oResult = null;
 
-		oResult = this.oCutter.setTexts();
+		oResult = this.oCutter.setText();
 
 		assertInstanceOf(Cutter, oResult);
 	},
@@ -309,7 +309,7 @@ TestCase("CutterSetTextsTest", sinon.testCase({
 	{
 		var oResult = null;
 
-		oResult = this.oCutter.setTexts(null);
+		oResult = this.oCutter.setText(null);
 
 		assertInstanceOf(Cutter, oResult);
 	},
@@ -322,7 +322,7 @@ TestCase("CutterSetTextsTest", sinon.testCase({
 		};
 		this.oCutter.oTexts = oObject;
 
-		this.oCutter.setTexts(oObject2);
+		this.oCutter.setText(oObject2);
 
 		assertSame(oObject2, this.oCutter.oTexts);
 	},
@@ -332,7 +332,7 @@ TestCase("CutterSetTextsTest", sinon.testCase({
 		var oObject2 = {};
 		var oResult = null;
 
-		oResult = this.oCutter.setTexts(oObject2);
+		oResult = this.oCutter.setText(oObject2);
 
 		assertInstanceOf(Cutter, oResult);
 	},
@@ -536,14 +536,14 @@ TestCase("CutterCreateViewMoreTest", sinon.testCase({
 	{
 		cutterSetUp.call(this);
 	},
-	"test should create a link object and it must be setted to oViewMore": function()
+	"test should create a link object and it must be set to oViewMore": function()
 	{
 		this.oCutter.createViewMore();
 
 		assertTagName("a", this.oCutter.oViewMore);
-		assertClassName(this.oCutter.oClasses.more, this.oCutter.oViewMore);
-		assertEquals(this.oCutter.oTexts.more, this.oCutter.oViewMore.innerHTML);
-		assertEquals(this.oCutter.oTexts.more, this.oCutter.oViewMore.title);
+		assertClassName(this.oCutter.oClasses, this.oCutter.oViewMore);
+		assertEquals(this.oCutter.oTexts, this.oCutter.oViewMore.innerHTML);
+		assertEquals(this.oCutter.oTexts, this.oCutter.oViewMore.title);
 	},
 	tearDown: function()
 	{


### PR DESCRIPTION
I believe the modifications made to the API will make it slightly easier to use. Also the "href='#'" in the link element were causing the page to scroll to the top when the link was clicked.
